### PR TITLE
added changes to search by country

### DIFF
--- a/src/app/components/country/country.component.html
+++ b/src/app/components/country/country.component.html
@@ -5,13 +5,20 @@
               (selected)="selected($event)"
               name="searchQuery" [(ngModel)]="searchQuery" placeholder="Enter country name" autofocus>
 </ng-select>
-
-<div *ngIf="searchRes">
+<br>
+<div *ngIf="searchError" >
+	<h2> Popular In {{countryName}}</h2>
+	<h3 class="error">Sorry,No Data Available!</h3>
+</div>
+<div  *ngIf="searchRes && !searchError">
+	<h2> Popular In {{countryName}}</h2>
 	<div class="row">
 		<div class="col-md-12">
+			<div *ngIf="!searchError">
 			<div class="well" *ngFor="let res of pagedItems">
 				<img src="{{res.image[3]['#text']}}" height="50" alt="{{res.name}}">
 				<a routerLink="/artist/{{res.name}}">{{res.name}}</a>
+			</div>
 			</div>
 		</div>
 	</div>

--- a/src/app/components/country/country.component.ts
+++ b/src/app/components/country/country.component.ts
@@ -21,10 +21,13 @@ export class CountryComponent {
     "New Zealand","Nicaragua","Niger","Nigeria","Niue","Norfolk Island","North Korea","Northern Ireland","Northern Mariana Islands","Norway","Oman","Pakistan","Palau","Palestine","Panama","Papua New Guinea","Paraguay","Peru","Philippines","Pitcairn","Poland","Portugal","Puerto Rico","Qatar","Reunion","Romania","Russian Federation","Rwanda","Saint Helena","Saint Kitts and Nevis","Saint Lucia","Saint Pierre and Miquelon","Saint Vincent and the Grenadines","Samoa","San Marino","Sao Tome and Principe","Saudi Arabia","Scotland","Senegal","Seychelles","Sierra Leone","Singapore","Slovakia","Slovenia","Solomon Islands","Somalia","South Africa","South Georgia and the South Sandwich Islands","South Korea","South Sudan","Spain","SriLanka","Sudan","Suriname","Svalbard and Jan Mayen","Swaziland","Sweden","Switzerland","Syria","Tajikistan","Tanzania","Thailand","Togo","Tokelau","Tonga","Trinidad and Tobago","Tunisia","Turkey","Turkmenistan","Turks and Caicos Islands","Tuvalu","Uganda","Ukraine","United Arab Emirates","United Kingdom","United States","United States Minor Outlying Islands","Uruguay","Uzbekistan","Vanuatu","Venezuela","Vietnam","Virgin Islands, British","Virgin Islands, U.S.","Wales","Wallis and Futuna","Western Sahara","Yemen","Yugoslavia","Zambia","Zimbabwe"
   ];
 
+  public searchError=false;
+  public countryName='';
   public value:any = {};
   
 
   public selected(value:any):void {
+    this.countryName=value.text;
     this.searchCountry(value.text);
   }
 
@@ -34,8 +37,15 @@ export class CountryComponent {
   searchCountry(countryName:string) {
 
 			this._spotifyService.searchCountry(countryName).subscribe(res => {
-				this.searchRes = res.topartists.artist;
-				this.setPage(1);
+          
+        if(res.error == null){
+          this.searchError=false;
+				  this.searchRes = res.topartists.artist;
+				  this.setPage(1);
+
+        }else{
+          this.searchError= true;
+        }
 			})
 		
 	}
@@ -45,5 +55,6 @@ export class CountryComponent {
         }
         this.pager = this._pagerService.getPager(this.searchRes.length, page);
         this.pagedItems = this.searchRes.slice(this.pager.startIndex, this.pager.endIndex + 1);
-	}
+	       
+  }
 }


### PR DESCRIPTION
Fixes [#46](https://github.com/jajodiaraghav/rTunes/issues/46).

> Add search button. Get data from last fm API only when the search button is clicked.

No need as it is a select dropdown

> If country name entered is blank display appropriate error info.

No query fired till any country is selected

> Show the search results in table format.

Done

> Also, if data for the selected country is not present display appropriate error.

Done. Error reproduction - select Srilanka from the dropdown.